### PR TITLE
Remove "fmt" dependency in js_notwasm.go

### DIFF
--- a/js/js_notwasm.go
+++ b/js/js_notwasm.go
@@ -7,7 +7,7 @@
 package js
 
 import (
-	"fmt"
+	"reflect"
 	"unsafe"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -118,7 +118,7 @@ func ValueOf(x interface{}) Value {
 	case []int8, []int16, []int32, []int64, []uint16, []uint32, []uint64, []float32, []float64:
 		return Value{v: id.Invoke(x)}
 	default:
-		panic(fmt.Sprintf("invalid arg: %T", x))
+		panic(`invalid arg: ` + reflect.TypeOf(x).String())
 	}
 }
 


### PR DESCRIPTION
Reduces the generated JS for a small project by around 1Mb