### PR TITLE
Add TypedArray

### DIFF
--- a/js/js_notwasm.go
+++ b/js/js_notwasm.go
@@ -116,11 +116,14 @@ func ValueOf(x interface{}) Value {
 		return x
 	case Callback:
 		return x.Value
+	case TypedArray:
+		return x.Value
 	case nil:
 		return Null()
 	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, unsafe.Pointer, string, []byte:
 		return Value{v: id.Invoke(x)}
 	case []int8, []int16, []int32, []int64, []uint16, []uint32, []uint64, []float32, []float64:
+		// TODO: Now slices must be passed to TypedArrayOf. Remove this.
 		return Value{v: id.Invoke(x)}
 	default:
 		panic(`invalid arg: ` + reflect.TypeOf(x).String())
@@ -186,6 +189,23 @@ func (v Value) String() string {
 
 func (v Value) InstanceOf(t Value) bool {
 	return instanceOf.Invoke(v, t).Bool()
+}
+
+type TypedArray struct {
+	Value
+}
+
+func TypedArrayOf(slice interface{}) *TypedArray {
+	switch slice := slice.(type) {
+	case []int8, []int16, []int32, []uint8, []uint16, []uint32, []float32, []float64:
+		return &TypedArray{Value{v: id.Invoke(slice)}};
+	default:
+		panic("TypedArrayOf: not a supported slice")
+	}
+}
+
+func (t *TypedArray) Release() {
+	t.Value = Null()
 }
 
 func GetInternalObject(v Value) interface{} {

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -23,7 +23,7 @@ func TestCallback(t *testing.T) {
 	c := js.NewCallback(func(args []js.Value) {
 		ch <- args[0].Int() + args[1].Int()
 	})
-	defer c.Close()
+	defer c.Release()
 
 	js.ValueOf(c).Invoke(1, 2)
 	got := <-ch
@@ -38,7 +38,7 @@ func TestCallbackObject(t *testing.T) {
 	c := js.NewCallback(func(args []js.Value) {
 		ch <- args[0].Get("foo").String()
 	})
-	defer c.Close()
+	defer c.Release()
 
 	js.ValueOf(c).Invoke(js.Global().Call("eval", `({"foo": "bar"})`))
 	got := <-ch
@@ -103,4 +103,26 @@ func TestInstanceOf(t *testing.T) {
 	if got != want {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
+}
+
+func TestTypedArrayOf(t *testing.T) {
+	testTypedArrayOf(t, "[]int8", []int8{0, -42, 0}, -42)
+	testTypedArrayOf(t, "[]int16", []int16{0, -42, 0}, -42)
+	testTypedArrayOf(t, "[]int32", []int32{0, -42, 0}, -42)
+	testTypedArrayOf(t, "[]uint8", []uint8{0, 42, 0}, 42)
+	testTypedArrayOf(t, "[]uint16", []uint16{0, 42, 0}, 42)
+	testTypedArrayOf(t, "[]uint32", []uint32{0, 42, 0}, 42)
+	testTypedArrayOf(t, "[]float32", []float32{0, -42.5, 0}, -42.5)
+	testTypedArrayOf(t, "[]float64", []float64{0, -42.5, 0}, -42.5)
+}
+
+func testTypedArrayOf(t *testing.T, name string, slice interface{}, want float64) {
+	t.Run(name, func(t *testing.T) {
+		a := js.TypedArrayOf(slice)
+		got := a.Index(1).Float()
+		a.Release()
+		if got != want {
+			t.Errorf("got %#v, want %#v", got, want)
+		}
+	})
 }

--- a/js/js_wasm.go
+++ b/js/js_wasm.go
@@ -50,10 +50,8 @@ var (
 	int8Array    = js.Global().Get("Int8Array")
 	int16Array   = js.Global().Get("Int16Array")
 	int32Array   = js.Global().Get("Int32Array")
-	int64Array   = js.Global().Get("Int64Array")
 	uint16Array  = js.Global().Get("Uint16Array")
 	uint32Array  = js.Global().Get("Uint32Array")
-	uint64Array  = js.Global().Get("Uint64Array")
 	float32Array = js.Global().Get("Float32Array")
 	float64Array = js.Global().Get("Float64Array")
 )
@@ -62,6 +60,7 @@ func ValueOf(x interface{}) Value {
 	var xh *reflect.SliceHeader
 	var class js.Value
 	size := 0
+	// TODO: Now slices must be passed to TypedArrayOf. Remove this.
 	switch x := x.(type) {
 	case []int8:
 		size = 1
@@ -111,6 +110,12 @@ func ValueOf(x interface{}) Value {
 
 	u8 := js.ValueOf(b)
 	return class.New(u8.Get("buffer"), u8.Get("byteOffset"), xh.Len)
+}
+
+type TypedArray = js.TypedArray
+
+func TypedArrayOf(slice interface{}) TypedArray {
+	return js.TypedArrayOf(slice)
 }
 
 func GetInternalObject(v Value) interface{} {


### PR DESCRIPTION
This PR leaves `ValueOf` accepting slices for backward compatibility. I plan to remove this to follow the current `syscall/js` behavior later.