### PR TITLE
Remove TypedArray support in ValueOf

### DIFF
--- a/js/js_notwasm.go
+++ b/js/js_notwasm.go
@@ -122,9 +122,6 @@ func ValueOf(x interface{}) Value {
 		return Null()
 	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, unsafe.Pointer, string, []byte:
 		return Value{v: id.Invoke(x)}
-	case []int8, []int16, []int32, []int64, []uint16, []uint32, []uint64, []float32, []float64:
-		// TODO: Now slices must be passed to TypedArrayOf. Remove this.
-		return Value{v: id.Invoke(x)}
 	default:
 		panic(`invalid arg: ` + reflect.TypeOf(x).String())
 	}

--- a/js/js_wasm.go
+++ b/js/js_wasm.go
@@ -7,9 +7,7 @@
 package js
 
 import (
-	"reflect"
 	"syscall/js"
-	"unsafe"
 )
 
 func Global() Value {
@@ -46,62 +44,8 @@ type Error = js.Error
 
 type Value = js.Value
 
-var (
-	int8Array    = js.Global().Get("Int8Array")
-	int16Array   = js.Global().Get("Int16Array")
-	int32Array   = js.Global().Get("Int32Array")
-	uint16Array  = js.Global().Get("Uint16Array")
-	uint32Array  = js.Global().Get("Uint32Array")
-	float32Array = js.Global().Get("Float32Array")
-	float64Array = js.Global().Get("Float64Array")
-)
-
 func ValueOf(x interface{}) Value {
-	var xh *reflect.SliceHeader
-	var class js.Value
-	size := 0
-	// TODO: Now slices must be passed to TypedArrayOf. Remove this.
-	switch x := x.(type) {
-	case []int8:
-		size = 1
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = int8Array
-	case []int16:
-		size = 2
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = int16Array
-	case []int32:
-		size = 4
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = int32Array
-	case []uint16:
-		size = 2
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = uint16Array
-	case []uint32:
-		size = 4
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = uint32Array
-	case []float32:
-		size = 4
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = float32Array
-	case []float64:
-		size = 8
-		xh = (*reflect.SliceHeader)(unsafe.Pointer(&x))
-		class = float64Array
-	default:
-		return js.ValueOf(x)
-	}
-
-	var b []byte
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = xh.Data
-	bh.Len = xh.Len * size
-	bh.Cap = xh.Cap * size
-
-	u8 := js.ValueOf(b)
-	return class.New(u8.Get("buffer"), u8.Get("byteOffset"), xh.Len)
+	return js.ValueOf(x)
 }
 
 type TypedArray = js.TypedArray


### PR DESCRIPTION
This removes a deprecated behavior that has been kept for backward compatibility.